### PR TITLE
Fix crashes with one test case.

### DIFF
--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -382,7 +382,7 @@ class HtmlTestResult(TextTestResult):
             if testRunner.report_name is not None:
                 report_name_body = testRunner.report_name
             else:
-                report_name_body = self.default_prefix + "_".join(strip_module_names(list(all_results.keys())))[0:128]
+                report_name_body = self.default_prefix + "_".join(strip_module_names(list(all_results.keys())))[:128]
             self.generate_file(testRunner, report_name_body, html_file)
 
     def generate_file(self, testRunner, report_name, report):

--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -382,7 +382,7 @@ class HtmlTestResult(TextTestResult):
             if testRunner.report_name is not None:
                 report_name_body = testRunner.report_name
             else:
-                report_name_body = self.default_prefix + "_".join(strip_module_names(list(all_results.keys())))
+                report_name_body = self.default_prefix + "_".join(strip_module_names(list(all_results.keys())))[0:128]
             self.generate_file(testRunner, report_name_body, html_file)
 
     def generate_file(self, testRunner, report_name, report):

--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -155,7 +155,7 @@ class HtmlTestResult(TextTestResult):
 
             if self.showAll:
                 self.stream.writeln(
-                    "{} ({:3f})s".format(verbose_str, test_info.elapsed_time))
+                    "{} ({:3f}s)".format(verbose_str, test_info.elapsed_time))
             elif self.dots:
                 self.stream.write(short_str)
 

--- a/HtmlTestRunner/result.py
+++ b/HtmlTestRunner/result.py
@@ -51,11 +51,11 @@ def strip_module_names(testcase_names):
     """Examine all given test case names and strip them the minimal
     names needed to distinguish each. This prevents cases where test
     cases housed in different files but with the same names cause clashes."""
-    result = testcase_names.copy()
+    result = list(testcase_names)
     for i, testcase in enumerate(testcase_names):
         classname = testcase.split(".")[-1]
         duplicate_found = False
-        testcase_names_ = testcase_names.copy()
+        testcase_names_ = list(testcase_names)
         del testcase_names_[i]
         for testcase_ in testcase_names_:
             classname_ = testcase_.split(".")[-1]


### PR DESCRIPTION
Fix if you pass only one test case to the test runner the HTML generation fails with this error : AttributeError: 'list' object has no attribute 'copy'.
Fixed "File name too long" error because all the test suites names are concatenated to generate the html file and I have a lot of test suites...